### PR TITLE
use event emitter for app creation

### DIFF
--- a/src/resources/App.js
+++ b/src/resources/App.js
@@ -48,7 +48,7 @@ const createAppHandler = (
             ws.on('message', async message => {
               const {type, ...data} = JSON.parse(message);
 
-              appStatusEventEmitter.emit(type, data);
+              appStatusEventEmitter.emit(type, {...data, txId});
             });
           });
 


### PR DESCRIPTION
The app creation will now use an event emitter instead of a promise. The events that will be emitted are:
- `signable_tx` with the id of the transaction
- `complete` with the app information
- `error` with the error object
- `txHash` with the txHash for each transaction we transmit
- `receipt` with the receipt for each transaction we transmit
- `message` with the message from the API, for any message that does not match the above events
The `authorize` message from the server will not emit an event as we want the authentication to be transparent and there is no point in showing this to a user.

The client will use the event emitter like so:
```
const subscriber = await mainApp.apps.create(...);

subscriber.on('message', message => {
  console.log('message', message);
});

subscriber.on('complete', data => {
  console.log('completed', data);
});

subscriber.on('signable_tx', data => {
  console.log('signable_tx', data);
});

subscriber.on('error', data => {
  console.log('error', data);
});
```